### PR TITLE
hookのエラーを修正

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path // empty' | xargs -I {} sh -c 'if [[ {} == *.go ]]; then gofmt -w \"{}\" && goimports -w \"{}\"; fi'"
+            "command": "FILE=$(jq -r '.tool_input.file_path // empty'); if [[ \"$FILE\" == *.go ]]; then gofmt -w \"$FILE\" && goimports -w \"$FILE\"; fi"
           }
         ]
       }

--- a/internal/service/habit_done_test.go
+++ b/internal/service/habit_done_test.go
@@ -11,8 +11,8 @@ import (
 
 type dailyRecordRepositoryMock struct {
 	findDoneHabitIDsByDateFn func(ctx context.Context, date string) (map[int64]bool, error)
-	createFn                func(ctx context.Context, habitID int64, date string) error
-	deleteFn                func(ctx context.Context, habitID int64, date string) error
+	createFn                 func(ctx context.Context, habitID int64, date string) error
+	deleteFn                 func(ctx context.Context, habitID int64, date string) error
 }
 
 func (m *dailyRecordRepositoryMock) FindDoneHabitIDsByDate(ctx context.Context, date string) (map[int64]bool, error) {


### PR DESCRIPTION
## Summary
- `xargs -I {}` によるコマンド行長超過エラーを修正
- `FILE=$(jq ...)` パターンに変更し、フルパス使用時の `xargs: command line cannot be assembled, too long` を解消
- あわせて `gofmt` によるアライメント修正を適用

## Test plan
- [x] `.go` ファイルを編集してもフックエラーが出ないことを確認
- [x] `gofmt` / `goimports` が正常に適用されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal development tooling and test code formatting for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->