### PR TITLE
feat(history): add history display page with date range toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ cmd/app/app
 data/
 tmp/
 .env
+.playwright-cli/

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -27,6 +27,7 @@ func main() {
 	defer conn.Close()
 
 	indexTmpl := template.Must(template.ParseFS(templates.FS, "index.html"))
+	historyTmpl := template.Must(template.ParseFS(templates.FS, "history.html"))
 
 	habitRepository := repository.NewSQLiteHabitRepository(conn)
 	habitService := service.NewHabitService(habitRepository)
@@ -34,8 +35,9 @@ func main() {
 	dailyRecordRepo := repository.NewDailyRecord(conn)
 	habitDoneService := service.NewHabitDone(dailyRecordRepo, nil)
 	expService := service.NewExpService(dailyRecordRepo)
+	historyService := service.NewHistoryService(habitService, dailyRecordRepo, nil)
 
-	h := handler.New(indexTmpl, habitService, habitDoneService, expService)
+	h := handler.New(indexTmpl, historyTmpl, habitService, habitDoneService, expService, historyService)
 
 	addr := ":8080"
 	log.Printf("starting server on %s", addr)

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -15,13 +15,19 @@ import (
 
 type Handler struct {
 	tmpl             *template.Template
+	historyTmpl      *template.Template
 	service          service.HabitService
 	habitDoneService habitDoneService
 	expService       expService
+	historyService   historyService
 }
 
 type expService interface {
 	Calculate(ctx context.Context, habits []model.Habit) (*service.ExpResult, error)
+}
+
+type historyService interface {
+	BuildHistory(ctx context.Context, rangeType string) (*model.HistoryData, error)
 }
 
 type habitDoneService interface {
@@ -38,15 +44,18 @@ func formatDate(t time.Time) string {
 	return t.Format("2006年01月02日") + "(" + weekdays[t.Weekday()] + ")"
 }
 
-func New(tmpl *template.Template, svc service.HabitService, doneSvc habitDoneService, expSvc expService) http.Handler {
+func New(tmpl *template.Template, historyTmpl *template.Template, svc service.HabitService, doneSvc habitDoneService, expSvc expService, historySvc historyService) http.Handler {
 	h := &Handler{
 		tmpl:             tmpl,
+		historyTmpl:      historyTmpl,
 		service:          svc,
 		habitDoneService: doneSvc,
 		expService:       expSvc,
+		historyService:   historySvc,
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /", h.handleDashboard)
+	mux.HandleFunc("GET /history", h.handleHistory)
 	mux.HandleFunc("POST /habits/{id}/done", h.handleHabitDone)
 	mux.HandleFunc("POST /habits/{id}/undone", h.handleHabitUndone)
 	return mux
@@ -99,6 +108,25 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 	var buf bytes.Buffer
 	if err := h.tmpl.Execute(&buf, data); err != nil {
+		log.Printf("template render error: %v", err)
+		http.Error(w, "render error", http.StatusInternalServerError)
+		return
+	}
+	buf.WriteTo(w)
+}
+
+func (h *Handler) handleHistory(w http.ResponseWriter, r *http.Request) {
+	rangeType := r.URL.Query().Get("range")
+
+	data, err := h.historyService.BuildHistory(r.Context(), rangeType)
+	if err != nil {
+		log.Printf("build history error: %v", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	var buf bytes.Buffer
+	if err := h.historyTmpl.Execute(&buf, data); err != nil {
 		log.Printf("template render error: %v", err)
 		http.Error(w, "render error", http.StatusInternalServerError)
 		return

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -385,6 +385,39 @@ func TestGetHistory_WeekRange(t *testing.T) {
 	}
 }
 
+func TestGetHistory_Returns500WhenServiceFails(t *testing.T) {
+	indexTmpl := template.Must(template.ParseFS(templates.FS, "index.html"))
+	historyTmpl := template.Must(template.New("history").Parse(`ok`))
+	historySvc := historyServiceStub{
+		buildHistoryFn: func(ctx context.Context, rangeType string) (*model.HistoryData, error) {
+			return nil, errors.New("db down")
+		},
+	}
+	h := handler.New(indexTmpl, historyTmpl, nil, habitDoneServiceStub{}, expServiceStub{}, historySvc)
+
+	req := httptest.NewRequest(http.MethodGet, "/history", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+}
+
+func TestGetHistory_Returns500WhenTemplateFails(t *testing.T) {
+	indexTmpl := template.Must(template.ParseFS(templates.FS, "index.html"))
+	historyTmpl := template.Must(template.New("history").Parse(`{{.NotExisting.Field}}`))
+	h := handler.New(indexTmpl, historyTmpl, nil, habitDoneServiceStub{}, expServiceStub{}, historyServiceStub{})
+
+	req := httptest.NewRequest(http.MethodGet, "/history", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", w.Code)
+	}
+}
+
 func TestPostHabitDone_ReturnsBadRequestForInvalidID(t *testing.T) {
 	tmpl := template.Must(template.ParseFS(templates.FS, "index.html"))
 	h := handler.New(tmpl, nil, nil, habitDoneServiceStub{

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -73,7 +73,7 @@ func (m *mockHabitService) FindAll(_ context.Context) ([]model.Habit, error) {
 func TestGetDashboard(t *testing.T) {
 	tmpl := template.Must(template.New("index").Parse(`<h1>Habit Growth Tracker</h1>`))
 	svc := &mockHabitService{}
-	h := handler.New(tmpl, svc, habitDoneServiceStub{}, expServiceStub{})
+	h := handler.New(tmpl, nil, svc, habitDoneServiceStub{}, expServiceStub{}, historyServiceStub{})
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
@@ -97,7 +97,7 @@ func TestGetDashboard_RendersHabitCards(t *testing.T) {
 			{ID: 3, Name: "運動"},
 		},
 	}
-	h := handler.New(tmpl, svc, habitDoneServiceStub{}, expServiceStub{})
+	h := handler.New(tmpl, nil, svc, habitDoneServiceStub{}, expServiceStub{}, historyServiceStub{})
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
@@ -118,7 +118,7 @@ func TestGetDashboard_RendersHabitCards(t *testing.T) {
 func TestGetDashboard_Returns500WhenServiceFails(t *testing.T) {
 	tmpl := template.Must(template.ParseFS(templates.FS, "index.html"))
 	svc := &mockHabitService{err: errors.New("db down")}
-	h := handler.New(tmpl, svc, habitDoneServiceStub{}, expServiceStub{})
+	h := handler.New(tmpl, nil, svc, habitDoneServiceStub{}, expServiceStub{}, historyServiceStub{})
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
@@ -146,7 +146,7 @@ func TestGetDashboard_ShowsDoneStateFromService(t *testing.T) {
 			return map[int64]bool{1: true}, nil
 		},
 	}
-	h := handler.New(tmpl, svc, doneSvc, expServiceStub{})
+	h := handler.New(tmpl, nil, svc, doneSvc, expServiceStub{}, historyServiceStub{})
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
@@ -168,12 +168,12 @@ func TestPostHabitDone_RedirectsToDashboard(t *testing.T) {
 	tmpl := template.Must(template.ParseFS(templates.FS, "index.html"))
 
 	var gotHabitID int64
-	h := handler.New(tmpl, nil, habitDoneServiceStub{
+	h := handler.New(tmpl, nil, nil, habitDoneServiceStub{
 		markDoneFn: func(ctx context.Context, habitID int64) error {
 			gotHabitID = habitID
 			return nil
 		},
-	}, expServiceStub{})
+	}, expServiceStub{}, historyServiceStub{})
 
 	req := httptest.NewRequest(http.MethodPost, "/habits/2/done", nil)
 	w := httptest.NewRecorder()
@@ -195,12 +195,12 @@ func TestPostHabitUndone_RedirectsToDashboard(t *testing.T) {
 	tmpl := template.Must(template.ParseFS(templates.FS, "index.html"))
 
 	var gotHabitID int64
-	h := handler.New(tmpl, nil, habitDoneServiceStub{
+	h := handler.New(tmpl, nil, nil, habitDoneServiceStub{
 		markUndoneFn: func(ctx context.Context, habitID int64) error {
 			gotHabitID = habitID
 			return nil
 		},
-	}, expServiceStub{})
+	}, expServiceStub{}, historyServiceStub{})
 
 	req := httptest.NewRequest(http.MethodPost, "/habits/3/undone", nil)
 	w := httptest.NewRecorder()
@@ -220,12 +220,12 @@ func TestPostHabitUndone_RedirectsToDashboard(t *testing.T) {
 
 func TestPostHabitUndone_ReturnsBadRequestForInvalidID(t *testing.T) {
 	tmpl := template.Must(template.ParseFS(templates.FS, "index.html"))
-	h := handler.New(tmpl, nil, habitDoneServiceStub{
+	h := handler.New(tmpl, nil, nil, habitDoneServiceStub{
 		markUndoneFn: func(ctx context.Context, habitID int64) error {
 			t.Fatal("MarkUndone should not be called for invalid ID")
 			return nil
 		},
-	}, expServiceStub{})
+	}, expServiceStub{}, historyServiceStub{})
 
 	req := httptest.NewRequest(http.MethodPost, "/habits/not-a-number/undone", nil)
 	w := httptest.NewRecorder()
@@ -237,14 +237,162 @@ func TestPostHabitUndone_ReturnsBadRequestForInvalidID(t *testing.T) {
 	}
 }
 
+type historyServiceStub struct {
+	buildHistoryFn func(ctx context.Context, rangeType string) (*model.HistoryData, error)
+}
+
+func (s historyServiceStub) BuildHistory(ctx context.Context, rangeType string) (*model.HistoryData, error) {
+	if s.buildHistoryFn != nil {
+		return s.buildHistoryFn(ctx, rangeType)
+	}
+	return &model.HistoryData{CurrentRange: "month"}, nil
+}
+
+func TestGetHistory_RendersHistoryPage(t *testing.T) {
+	indexTmpl := template.Must(template.ParseFS(templates.FS, "index.html"))
+	historyTmpl := template.Must(template.New("history").Parse(
+		`<h1>履歴</h1>{{range .Rows}}<tr><td>{{.Date}}</td></tr>{{end}}`,
+	))
+	svc := &mockHabitService{}
+	historySvc := historyServiceStub{
+		buildHistoryFn: func(ctx context.Context, rangeType string) (*model.HistoryData, error) {
+			return &model.HistoryData{
+				Habits: []model.Habit{{ID: 1, Name: "早起き"}},
+				Rows: []model.HistoryRow{
+					{Date: "2026-04-12", DoneByHabit: map[int64]bool{1: true}},
+					{Date: "2026-04-11", DoneByHabit: map[int64]bool{}},
+				},
+				CurrentRange: "month",
+			}, nil
+		},
+	}
+	h := handler.New(indexTmpl, historyTmpl, svc, habitDoneServiceStub{}, expServiceStub{}, historySvc)
+
+	req := httptest.NewRequest(http.MethodGet, "/history", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "履歴") {
+		t.Errorf("body does not contain '履歴': %s", body)
+	}
+	if !strings.Contains(body, "2026-04-12") {
+		t.Errorf("body does not contain '2026-04-12': %s", body)
+	}
+}
+
+func TestGetDashboard_HasHistoryLink(t *testing.T) {
+	tmpl := template.Must(template.ParseFS(templates.FS, "index.html"))
+	svc := &mockHabitService{}
+	h := handler.New(tmpl, nil, svc, habitDoneServiceStub{}, expServiceStub{}, historyServiceStub{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "/history") {
+		t.Errorf("dashboard does not contain link to /history")
+	}
+}
+
+func TestGetHistory_RendersActualTemplate(t *testing.T) {
+	indexTmpl := template.Must(template.ParseFS(templates.FS, "index.html"))
+	historyTmpl := template.Must(template.ParseFS(templates.FS, "history.html"))
+	historySvc := historyServiceStub{
+		buildHistoryFn: func(ctx context.Context, rangeType string) (*model.HistoryData, error) {
+			return &model.HistoryData{
+				Habits: []model.Habit{
+					{ID: 1, Name: "早起き"},
+					{ID: 2, Name: "英語学習"},
+				},
+				Rows: []model.HistoryRow{
+					{Date: "2026-04-12", DoneByHabit: map[int64]bool{1: true}},
+					{Date: "2026-04-11", DoneByHabit: map[int64]bool{1: true, 2: true}},
+				},
+				CurrentRange: "month",
+			}, nil
+		},
+	}
+	h := handler.New(indexTmpl, historyTmpl, nil, habitDoneServiceStub{}, expServiceStub{}, historySvc)
+
+	req := httptest.NewRequest(http.MethodGet, "/history", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+
+	// テーブルヘッダに習慣名
+	for _, name := range []string{"早起き", "英語学習"} {
+		if !strings.Contains(body, name) {
+			t.Errorf("body does not contain %q", name)
+		}
+	}
+	// 達成: ○、未達成: -
+	if !strings.Contains(body, "○") {
+		t.Errorf("body does not contain '○'")
+	}
+	if !strings.Contains(body, "-") {
+		t.Errorf("body does not contain '-'")
+	}
+	// 切り替えリンク
+	if !strings.Contains(body, "range=week") {
+		t.Errorf("body does not contain link to week range")
+	}
+	if !strings.Contains(body, "range=month") {
+		t.Errorf("body does not contain link to month range")
+	}
+	// ダッシュボードへの戻りリンク
+	if !strings.Contains(body, "href=\"/\"") {
+		t.Errorf("body does not contain link to dashboard")
+	}
+}
+
+func TestGetHistory_WeekRange(t *testing.T) {
+	indexTmpl := template.Must(template.ParseFS(templates.FS, "index.html"))
+	historyTmpl := template.Must(template.New("history").Parse(
+		`range={{.CurrentRange}}`,
+	))
+	var gotRange string
+	historySvc := historyServiceStub{
+		buildHistoryFn: func(ctx context.Context, rangeType string) (*model.HistoryData, error) {
+			gotRange = rangeType
+			return &model.HistoryData{CurrentRange: rangeType}, nil
+		},
+	}
+	h := handler.New(indexTmpl, historyTmpl, nil, habitDoneServiceStub{}, expServiceStub{}, historySvc)
+
+	req := httptest.NewRequest(http.MethodGet, "/history?range=week", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if gotRange != "week" {
+		t.Errorf("service received range = %q, want %q", gotRange, "week")
+	}
+	if !strings.Contains(w.Body.String(), "range=week") {
+		t.Errorf("body does not contain 'range=week': %s", w.Body.String())
+	}
+}
+
 func TestPostHabitDone_ReturnsBadRequestForInvalidID(t *testing.T) {
 	tmpl := template.Must(template.ParseFS(templates.FS, "index.html"))
-	h := handler.New(tmpl, nil, habitDoneServiceStub{
+	h := handler.New(tmpl, nil, nil, habitDoneServiceStub{
 		markDoneFn: func(ctx context.Context, habitID int64) error {
 			t.Fatal("MarkDone should not be called for invalid ID")
 			return nil
 		},
-	}, expServiceStub{})
+	}, expServiceStub{}, historyServiceStub{})
 
 	req := httptest.NewRequest(http.MethodPost, "/habits/not-a-number/done", nil)
 	w := httptest.NewRecorder()
@@ -275,7 +423,7 @@ func TestGetDashboard_ShowsStreak(t *testing.T) {
 			return 0, nil
 		},
 	}
-	h := handler.New(tmpl, svc, doneSvc, expServiceStub{})
+	h := handler.New(tmpl, nil, svc, doneSvc, expServiceStub{}, historyServiceStub{})
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
@@ -311,7 +459,7 @@ func TestGetDashboard_ShowsExpAndLevel(t *testing.T) {
 			}, nil
 		},
 	}
-	h := handler.New(tmpl, svc, habitDoneServiceStub{}, expSvc)
+	h := handler.New(tmpl, nil, svc, habitDoneServiceStub{}, expSvc, historyServiceStub{})
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()

--- a/internal/model/history.go
+++ b/internal/model/history.go
@@ -1,0 +1,12 @@
+package model
+
+type HistoryRow struct {
+	Date        string
+	DoneByHabit map[int64]bool
+}
+
+type HistoryData struct {
+	Habits       []Habit
+	Rows         []HistoryRow
+	CurrentRange string
+}

--- a/internal/repository/daily_record.go
+++ b/internal/repository/daily_record.go
@@ -84,6 +84,34 @@ func (r *DailyRecord) CountByHabitID(ctx context.Context) (map[int64]int, error)
 	return counts, nil
 }
 
+func (r *DailyRecord) FindByDateRange(ctx context.Context, from, to string) (map[string]map[int64]bool, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT strftime('%Y-%m-%d', date), habit_id FROM daily_records
+		WHERE date BETWEEN ? AND ?
+	`, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("find by date range: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[string]map[int64]bool)
+	for rows.Next() {
+		var date string
+		var habitID int64
+		if err := rows.Scan(&date, &habitID); err != nil {
+			return nil, fmt.Errorf("scan date range record: %w", err)
+		}
+		if result[date] == nil {
+			result[date] = make(map[int64]bool)
+		}
+		result[date][habitID] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate date range records: %w", err)
+	}
+	return result, nil
+}
+
 func (r *DailyRecord) DeleteByHabitAndDate(ctx context.Context, habitID int64, date string) error {
 	if _, err := r.db.ExecContext(ctx, `
 		DELETE FROM daily_records WHERE habit_id = ? AND date = ?

--- a/internal/repository/daily_record_test.go
+++ b/internal/repository/daily_record_test.go
@@ -186,6 +186,72 @@ func TestDailyRecordRepository_CountByHabitID_Empty(t *testing.T) {
 	}
 }
 
+func TestDailyRecordRepository_FindByDateRange(t *testing.T) {
+	conn, err := db.Open(":memory:", migrations.FS)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer conn.Close()
+
+	repo := repository.NewDailyRecord(conn)
+	ctx := context.Background()
+
+	// 複数日・複数習慣の記録を作成
+	if err := repo.Create(ctx, 1, "2026-04-01"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := repo.Create(ctx, 2, "2026-04-01"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := repo.Create(ctx, 1, "2026-04-03"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// 範囲外の記録
+	if err := repo.Create(ctx, 1, "2026-03-31"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	result, err := repo.FindByDateRange(ctx, "2026-04-01", "2026-04-03")
+	if err != nil {
+		t.Fatalf("FindByDateRange: %v", err)
+	}
+
+	// 2026-04-01 に habit 1, 2 が達成
+	if !result["2026-04-01"][1] {
+		t.Error("expected habit 1 done on 2026-04-01")
+	}
+	if !result["2026-04-01"][2] {
+		t.Error("expected habit 2 done on 2026-04-01")
+	}
+	// 2026-04-03 に habit 1 が達成
+	if !result["2026-04-03"][1] {
+		t.Error("expected habit 1 done on 2026-04-03")
+	}
+	// 範囲外の 2026-03-31 は含まれない
+	if _, ok := result["2026-03-31"]; ok {
+		t.Error("expected 2026-03-31 to not be in result")
+	}
+}
+
+func TestDailyRecordRepository_FindByDateRange_Empty(t *testing.T) {
+	conn, err := db.Open(":memory:", migrations.FS)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer conn.Close()
+
+	repo := repository.NewDailyRecord(conn)
+	ctx := context.Background()
+
+	result, err := repo.FindByDateRange(ctx, "2026-04-01", "2026-04-30")
+	if err != nil {
+		t.Fatalf("FindByDateRange: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty map, got %v", result)
+	}
+}
+
 func TestDailyRecordRepository_CreateIsIdempotent(t *testing.T) {
 	conn, err := db.Open(":memory:", migrations.FS)
 	if err != nil {

--- a/internal/service/history_service.go
+++ b/internal/service/history_service.go
@@ -1,0 +1,74 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"habit-game/internal/model"
+)
+
+type habitFinder interface {
+	FindAll(ctx context.Context) ([]model.Habit, error)
+}
+
+type dateRangeFinder interface {
+	FindByDateRange(ctx context.Context, from, to string) (map[string]map[int64]bool, error)
+}
+
+type HistoryService struct {
+	habits  habitFinder
+	records dateRangeFinder
+	now     func() time.Time
+}
+
+func NewHistoryService(habits habitFinder, records dateRangeFinder, now func() time.Time) *HistoryService {
+	if now == nil {
+		now = time.Now
+	}
+	return &HistoryService{habits: habits, records: records, now: now}
+}
+
+func (s *HistoryService) BuildHistory(ctx context.Context, rangeType string) (*model.HistoryData, error) {
+	habits, err := s.habits.FindAll(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("find habits: %w", err)
+	}
+
+	today := s.now().In(JST)
+	if rangeType != "week" {
+		rangeType = "month"
+	}
+
+	var from time.Time
+	switch rangeType {
+	case "week":
+		from = today.AddDate(0, 0, -6)
+	case "month":
+		from = time.Date(today.Year(), today.Month(), 1, 0, 0, 0, 0, JST)
+	}
+	to := today
+
+	fromStr := from.Format(time.DateOnly)
+	toStr := to.Format(time.DateOnly)
+
+	records, err := s.records.FindByDateRange(ctx, fromStr, toStr)
+	if err != nil {
+		return nil, fmt.Errorf("find records: %w", err)
+	}
+
+	var rows []model.HistoryRow
+	for d := to; !d.Before(from); d = d.AddDate(0, 0, -1) {
+		dateStr := d.Format(time.DateOnly)
+		rows = append(rows, model.HistoryRow{
+			Date:        dateStr,
+			DoneByHabit: records[dateStr],
+		})
+	}
+
+	return &model.HistoryData{
+		Habits:       habits,
+		Rows:         rows,
+		CurrentRange: rangeType,
+	}, nil
+}

--- a/internal/service/history_service_test.go
+++ b/internal/service/history_service_test.go
@@ -1,0 +1,152 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"habit-game/internal/model"
+	"habit-game/internal/service"
+)
+
+type stubHabitFinder struct {
+	habits []model.Habit
+	err    error
+}
+
+func (s *stubHabitFinder) FindAll(_ context.Context) ([]model.Habit, error) {
+	return s.habits, s.err
+}
+
+type stubDateRangeFinder struct {
+	result map[string]map[int64]bool
+	err    error
+}
+
+func (s *stubDateRangeFinder) FindByDateRange(_ context.Context, _, _ string) (map[string]map[int64]bool, error) {
+	return s.result, s.err
+}
+
+func fixedNow(year int, month time.Month, day int) func() time.Time {
+	return func() time.Time {
+		return time.Date(year, month, day, 12, 0, 0, 0, service.JST)
+	}
+}
+
+func TestHistoryService_BuildHistory_Month(t *testing.T) {
+	habits := []model.Habit{
+		{ID: 1, Name: "早起き"},
+		{ID: 2, Name: "英語学習"},
+	}
+	records := map[string]map[int64]bool{
+		"2026-04-01": {1: true, 2: true},
+		"2026-04-03": {1: true},
+	}
+
+	svc := service.NewHistoryService(
+		&stubHabitFinder{habits: habits},
+		&stubDateRangeFinder{result: records},
+		fixedNow(2026, time.April, 5),
+	)
+
+	data, err := svc.BuildHistory(context.Background(), "month")
+	if err != nil {
+		t.Fatalf("BuildHistory: %v", err)
+	}
+
+	if data.CurrentRange != "month" {
+		t.Errorf("CurrentRange = %q, want %q", data.CurrentRange, "month")
+	}
+	if len(data.Habits) != 2 {
+		t.Fatalf("expected 2 habits, got %d", len(data.Habits))
+	}
+	// 当月1日〜今日 = 5日分の行
+	if len(data.Rows) != 5 {
+		t.Fatalf("expected 5 rows, got %d", len(data.Rows))
+	}
+	// 4/1 の habit 1 は達成
+	found := false
+	for _, row := range data.Rows {
+		if row.Date == "2026-04-01" {
+			found = true
+			if !row.DoneByHabit[1] {
+				t.Error("expected habit 1 done on 2026-04-01")
+			}
+			if !row.DoneByHabit[2] {
+				t.Error("expected habit 2 done on 2026-04-01")
+			}
+		}
+		if row.Date == "2026-04-02" {
+			if row.DoneByHabit[1] {
+				t.Error("expected habit 1 not done on 2026-04-02")
+			}
+		}
+	}
+	if !found {
+		t.Error("2026-04-01 row not found")
+	}
+}
+
+func TestHistoryService_BuildHistory_Week(t *testing.T) {
+	habits := []model.Habit{
+		{ID: 1, Name: "早起き"},
+	}
+	records := map[string]map[int64]bool{
+		"2026-04-10": {1: true},
+	}
+
+	svc := service.NewHistoryService(
+		&stubHabitFinder{habits: habits},
+		&stubDateRangeFinder{result: records},
+		fixedNow(2026, time.April, 12),
+	)
+
+	data, err := svc.BuildHistory(context.Background(), "week")
+	if err != nil {
+		t.Fatalf("BuildHistory: %v", err)
+	}
+
+	if data.CurrentRange != "week" {
+		t.Errorf("CurrentRange = %q, want %q", data.CurrentRange, "week")
+	}
+	// 今日から6日前〜今日 = 7日分
+	if len(data.Rows) != 7 {
+		t.Fatalf("expected 7 rows, got %d", len(data.Rows))
+	}
+	// 最初の日付が4/12（今日、新しい順）であること
+	if data.Rows[0].Date != "2026-04-12" {
+		t.Errorf("first row date = %q, want %q", data.Rows[0].Date, "2026-04-12")
+	}
+	// 最後の日付が4/6（6日前）であること
+	if data.Rows[6].Date != "2026-04-06" {
+		t.Errorf("last row date = %q, want %q", data.Rows[6].Date, "2026-04-06")
+	}
+}
+
+func TestHistoryService_BuildHistory_DescendingOrder(t *testing.T) {
+	habits := []model.Habit{
+		{ID: 1, Name: "早起き"},
+	}
+
+	svc := service.NewHistoryService(
+		&stubHabitFinder{habits: habits},
+		&stubDateRangeFinder{result: map[string]map[int64]bool{}},
+		fixedNow(2026, time.April, 3),
+	)
+
+	data, err := svc.BuildHistory(context.Background(), "month")
+	if err != nil {
+		t.Fatalf("BuildHistory: %v", err)
+	}
+
+	// 3日分: 4/3, 4/2, 4/1 の順（新しい順）
+	if len(data.Rows) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(data.Rows))
+	}
+	if data.Rows[0].Date != "2026-04-03" {
+		t.Errorf("first row = %q, want %q", data.Rows[0].Date, "2026-04-03")
+	}
+	if data.Rows[2].Date != "2026-04-01" {
+		t.Errorf("last row = %q, want %q", data.Rows[2].Date, "2026-04-01")
+	}
+}

--- a/internal/service/history_service_test.go
+++ b/internal/service/history_service_test.go
@@ -150,3 +150,22 @@ func TestHistoryService_BuildHistory_DescendingOrder(t *testing.T) {
 		t.Errorf("last row = %q, want %q", data.Rows[2].Date, "2026-04-01")
 	}
 }
+
+func TestHistoryService_BuildHistory_InvalidRangeFallsBackToMonth(t *testing.T) {
+	svc := service.NewHistoryService(
+		&stubHabitFinder{habits: []model.Habit{{ID: 1, Name: "早起き"}}},
+		&stubDateRangeFinder{result: map[string]map[int64]bool{}},
+		fixedNow(2026, time.April, 5),
+	)
+
+	data, err := svc.BuildHistory(context.Background(), "invalid")
+	if err != nil {
+		t.Fatalf("BuildHistory: %v", err)
+	}
+	if data.CurrentRange != "month" {
+		t.Errorf("CurrentRange = %q, want %q", data.CurrentRange, "month")
+	}
+	if len(data.Rows) != 5 {
+		t.Fatalf("expected 5 rows (month 4/1-4/5), got %d", len(data.Rows))
+	}
+}

--- a/templates/history.html
+++ b/templates/history.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>履歴 - Habit Growth Tracker</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #fff;
+      color: #111;
+      min-height: 100vh;
+    }
+
+    header {
+      padding: 24px 16px 16px;
+      border-bottom: 1px solid #e5e5e5;
+      max-width: 600px;
+      margin: 0 auto;
+    }
+
+    header h1 {
+      font-size: 1rem;
+      font-weight: 700;
+    }
+
+    .back-link {
+      display: inline-block;
+      margin-top: 4px;
+      font-size: 0.75rem;
+      color: #9ca3af;
+      text-decoration: none;
+    }
+
+    .back-link:hover {
+      color: #111;
+    }
+
+    main {
+      max-width: 600px;
+      margin: 0 auto;
+      padding: 0 16px 40px;
+    }
+
+    .range-nav {
+      display: flex;
+      gap: 16px;
+      padding: 12px 0;
+      border-bottom: 1px solid #e5e5e5;
+    }
+
+    .range-nav a {
+      font-size: 0.75rem;
+      font-weight: 400;
+      color: #9ca3af;
+      text-decoration: none;
+    }
+
+    .range-nav a.active {
+      font-weight: 700;
+      color: #111;
+    }
+
+    .history-table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    .history-table th {
+      font-size: 0.75rem;
+      font-weight: 700;
+      text-align: left;
+      padding: 12px 8px;
+      border-bottom: 1px solid #e5e5e5;
+    }
+
+    .history-table td {
+      font-size: 1rem;
+      padding: 12px 8px;
+      border-bottom: 1px solid #e5e5e5;
+    }
+
+    .history-table td.date-cell {
+      font-size: 0.75rem;
+      color: #9ca3af;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>履歴</h1>
+    <a class="back-link" href="/">← ダッシュボード</a>
+  </header>
+
+  <main>
+    <nav class="range-nav">
+      <a href="/history?range=week"{{if eq .CurrentRange "week"}} class="active"{{end}}>直近7日</a>
+      <a href="/history?range=month"{{if eq .CurrentRange "month"}} class="active"{{end}}>当月</a>
+    </nav>
+
+    <table class="history-table">
+      <thead>
+        <tr>
+          <th>日付</th>
+          {{range .Habits}}<th>{{.Name}}</th>{{end}}
+        </tr>
+      </thead>
+      <tbody>
+        {{range .Rows}}
+        <tr>
+          <td class="date-cell">{{.Date}}</td>
+          {{$row := .}}
+          {{range $.Habits}}
+          <td>{{if index $row.DoneByHabit .ID}}○{{else}}-{{end}}</td>
+          {{end}}
+        </tr>
+        {{end}}
+      </tbody>
+    </table>
+  </main>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -38,6 +38,18 @@
       color: #9ca3af;
     }
 
+    .history-link {
+      display: inline-block;
+      margin-top: 8px;
+      font-size: 0.75rem;
+      color: #9ca3af;
+      text-decoration: none;
+    }
+
+    .history-link:hover {
+      color: #111;
+    }
+
     main {
       max-width: 600px;
       margin: 0 auto;
@@ -119,6 +131,7 @@
     <h1>Habit Growth Tracker</h1>
     <p class="date">{{.Today}}</p>
     <p class="summary">総合 Lv.{{.TotalLevel}} &nbsp;/&nbsp; {{.TotalExp}} EXP</p>
+    <a class="history-link" href="/history">履歴を見る</a>
   </header>
 
   <main>

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -2,5 +2,5 @@ package templates
 
 import "embed"
 
-//go:embed index.html
+//go:embed index.html history.html
 var FS embed.FS


### PR DESCRIPTION
## Summary
- `GET /history` ルートで日付ごとの習慣達成履歴をテーブル形式で表示
- 「直近7日」「当月」の表示切り替えをクエリパラメータで実現
- ダッシュボードから履歴画面へのナビゲーションリンクを追加

## Test plan
- [x] `go test ./...` 全テスト通過
- [x] handler / service / repository 各層のユニットテスト追加済み
- [x] 達成基準 8項目すべて検証済み

Closes #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a history page (`/history`) to view habit completion records by date range
  * Users can toggle between weekly and monthly views
  * Added a navigation link from the dashboard to the history page

<!-- end of auto-generated comment: release notes by coderabbit.ai -->