### PR TITLE
refactor(dashboard): remove per-habit EXP display from habit rows

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -166,11 +166,10 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		cards[i] = model.HabitCard{
-			ID:       hab.ID,
-			Name:     hab.Name,
-			Done:     doneIDs[hab.ID],
-			TotalExp: expResult.HabitExp[hab.ID],
-			Streak:   streak,
+			ID:     hab.ID,
+			Name:   hab.Name,
+			Done:   doneIDs[hab.ID],
+			Streak: streak,
 		}
 	}
 

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -58,7 +58,7 @@ func (s expServiceStub) Calculate(ctx context.Context, habits []model.Habit) (*s
 	if s.calculateFn != nil {
 		return s.calculateFn(ctx, habits)
 	}
-	return &service.ExpResult{Level: 1, HabitExp: map[int64]int{}}, nil
+	return &service.ExpResult{Level: 1}, nil
 }
 
 type mockHabitService struct {
@@ -689,7 +689,6 @@ func TestGetDashboard_ShowsExpAndLevel(t *testing.T) {
 			return &service.ExpResult{
 				TotalExp: 200,
 				Level:    3,
-				HabitExp: map[int64]int{1: 99, 2: 33, 3: 68},
 			}, nil
 		},
 	}
@@ -709,7 +708,7 @@ func TestGetDashboard_ShowsExpAndLevel(t *testing.T) {
 	if !strings.Contains(body, "200 EXP") {
 		t.Errorf("body does not contain '200 EXP'")
 	}
-	if !strings.Contains(body, "99 EXP") {
-		t.Errorf("body does not contain '99 EXP' for habit 1")
+	if got := strings.Count(body, " EXP"); got != 1 {
+		t.Errorf("body should contain exactly 1 EXP display (header only), got %d", got)
 	}
 }

--- a/internal/model/dashboard.go
+++ b/internal/model/dashboard.go
@@ -1,11 +1,10 @@
 package model
 
 type HabitCard struct {
-	ID       int64
-	Name     string
-	Done     bool
-	TotalExp int
-	Streak   int
+	ID     int64
+	Name   string
+	Done   bool
+	Streak int
 }
 
 type DashboardData struct {

--- a/internal/service/exp_service.go
+++ b/internal/service/exp_service.go
@@ -22,7 +22,6 @@ func NewExpService(counter recordCounter) *ExpService {
 type ExpResult struct {
 	TotalExp int
 	Level    int
-	HabitExp map[int64]int
 }
 
 func (s *ExpService) Calculate(ctx context.Context, habits []model.Habit) (*ExpResult, error) {
@@ -31,17 +30,13 @@ func (s *ExpService) Calculate(ctx context.Context, habits []model.Habit) (*ExpR
 		return nil, fmt.Errorf("count records: %w", err)
 	}
 
-	habitExp := make(map[int64]int, len(habits))
 	totalExp := 0
 	for _, h := range habits {
-		exp := counts[h.ID] * h.ExpPerDone
-		habitExp[h.ID] = exp
-		totalExp += exp
+		totalExp += counts[h.ID] * h.ExpPerDone
 	}
 
 	return &ExpResult{
 		TotalExp: totalExp,
 		Level:    totalExp/100 + 1,
-		HabitExp: habitExp,
 	}, nil
 }

--- a/internal/service/exp_service_test.go
+++ b/internal/service/exp_service_test.go
@@ -62,29 +62,6 @@ func TestExpService_Calculate_WithRecords(t *testing.T) {
 	}
 }
 
-func TestExpService_Calculate_HabitExp(t *testing.T) {
-	mock := &recordCounterMock{
-		countByHabitIDFn: func(ctx context.Context) (map[int64]int, error) {
-			return map[int64]int{1: 3, 2: 1, 3: 2}, nil
-		},
-	}
-	svc := service.NewExpService(mock)
-
-	result, err := svc.Calculate(context.Background(), defaultHabits)
-	if err != nil {
-		t.Fatalf("Calculate: %v", err)
-	}
-	if result.HabitExp[1] != 99 {
-		t.Errorf("HabitExp[1] = %d, want 99", result.HabitExp[1])
-	}
-	if result.HabitExp[2] != 33 {
-		t.Errorf("HabitExp[2] = %d, want 33", result.HabitExp[2])
-	}
-	if result.HabitExp[3] != 68 {
-		t.Errorf("HabitExp[3] = %d, want 68", result.HabitExp[3])
-	}
-}
-
 func TestExpService_Calculate_LevelBoundaries(t *testing.T) {
 	singleHabit := []model.Habit{{ID: 1, Name: "test", ExpPerDone: 1}}
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -146,7 +146,7 @@
       <li class="habit-item">
         <div class="habit-info">
           <span class="habit-name{{if .Done}} done{{end}}">{{.Name}}</span>
-          <span class="habit-meta">{{.TotalExp}} EXP &nbsp;·&nbsp; {{.Streak}}日連続</span>
+          <span class="habit-meta">{{.Streak}}日連続</span>
         </div>
         {{if .Done}}
         <form method="post" action="/habits/{{.ID}}/undone">


### PR DESCRIPTION
## Summary

- ダッシュボードの習慣行から `{{.TotalExp}} EXP` 表示を削除し、`{{.Streak}}日連続` のみに簡素化
- 未使用となった `model.HabitCard.TotalExp` と `service.ExpResult.HabitExp` マップおよび生成処理を削除
- ヘッダの「総合 Lv.X / Y EXP」表示、`habits.exp_per_done` カラム、settings ページは従来どおり維持

Closes #37

## Test plan

- [x] `go test ./...` がすべてパス
- [x] ダッシュボードの習慣行が `{name} / N日連続` のみ表示され、per-habit EXP が出ていないことを playwright で確認
- [x] ヘッダ `総合 Lv.X / Y EXP` が表示され、達成ボタン押下で総合EXPが更新されることを確認
- [x] `/settings` ページが従来どおり動作することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed per-habit experience point tracking from the data model and calculations, simplifying the experience system.
  * Habit cards now display only daily streak count instead of showing both experience points and streak information.
  * Updated habit card display to reflect the simplified data structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->