### PR TITLE
chore: add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ data/
 tmp/
 .env
 .playwright-cli/
+.DS_Store


### PR DESCRIPTION
## Summary
- macOS の Finder が生成する `.DS_Store` を `.gitignore` に追加

## Test plan
- [x] `git check-ignore -v .DS_Store` で無視されることを確認
- [x] `git check-ignore -v docs/.DS_Store` でサブディレクトリ配下も無視されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to exclude macOS system files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->